### PR TITLE
Feature/add catch errors middleware

### DIFF
--- a/src/__tests__/catchErrors.spec.js
+++ b/src/__tests__/catchErrors.spec.js
@@ -1,0 +1,40 @@
+import 'isomorphic-fetch';
+
+import { expect } from 'chai';
+import { catchErrors } from '../index';
+
+const echo = (input, options) =>
+  Promise.resolve({ input, options });
+
+describe('catchErrors', () => {
+  it('do notthing for normal request', () => {
+    expect(() => {
+      catchErrors()(echo, 'url', {
+        method: 'post',
+        body: JSON.stringify({ name: 'catchErrors' }),
+      });
+    }).to.not.throw();
+  });
+
+  describe('when the options has a data property', () => {
+    it('throws an error', () =>
+      expect(() => {
+        catchErrors()(echo, 'url', {
+          method: 'post',
+          data: JSON.stringify({ name: 'catchErrors' }),
+        });
+      }).to.throw(/Did you try to use 'body:/)
+    );
+  });
+
+  describe('when the options has a POJO body property', () => {
+    it('throws an error', () =>
+      expect(() => {
+        catchErrors()(echo, 'url', {
+          method: 'post',
+          body: { name: 'catchErrors' },
+        });
+      }).to.throw(/Did you forgot to 'JSON\.stringify/)
+    );
+  });
+});

--- a/src/catchErrors.js
+++ b/src/catchErrors.js
@@ -1,0 +1,53 @@
+const OptionsKeyValidators = [
+  {
+    name: 'data',
+    validate: (input, options) => {
+      const verb = (options.method || 'GET').toUpperCase();
+      if (verb === 'GET' || verb === 'HEAD') {
+        return;
+      }
+      throw new Error(`Did you try to use 'body: ${JSON.stringify(options.data)}'?`);
+    },
+  },
+  {
+    name: 'body',
+    validate: (input, options) => {
+      const verb = (options.method || 'GET').toUpperCase();
+      if (verb === 'GET' || verb === 'HEAD') {
+        return;
+      }
+      function isPojo(obj) {
+        // Just copy for now.
+        // https://github.com/nickb1080/is-pojo/blob/master/lib/index.js
+        if (obj === null || typeof obj !== 'object') {
+          return false;
+        }
+        return Object.getPrototypeOf(obj) === Object.prototype;
+      }
+      // https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch#Parameters
+      if (isPojo(options.body)) {
+        throw new Error(`Did you forgot to 'JSON.stringify(${JSON.stringify(options.body)})'`);
+      }
+    },
+  },
+];
+
+function checkOptions(input, options) {
+  OptionsKeyValidators.forEach(({ name, validate }) => {
+    if (name in options) {
+      validate(input, options);
+    }
+  });
+}
+
+/**
+ * Check agains the final input and options to check if there's missing/misconfigured
+ * properties.
+ */
+export const catchErrors = () => (
+  (fetch, input, options = {}) => {
+    checkOptions(input, options);
+
+    return fetch(input, options);
+  }
+);

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
 export * from './console';
+export * from './catchErrors';


### PR DESCRIPTION
Moved from https://github.com/mjackson/http-client/pull/6#issuecomment-237446587
## Description

Add `catchError` middleware to validate `options` object. It may be very useful **in development**. Let me know what you think. Please note that the code is _not well organized_. Just want to get a first version and your feedback.
## TODOs
- [ ] Update `CHANGES.md`
- [ ] Clean up the code to match the general style of this project.
## References
- https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch#Parameters
